### PR TITLE
一部ベンダーのコーデックの利用を回避する実装

### DIFF
--- a/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
@@ -2,7 +2,6 @@ package org.m4m.android
 
 import android.media.MediaCodec
 import android.media.MediaCodecList
-import jp.studist.teachme_biz.controller.util.LogUtil
 import java.io.IOException
 import kotlin.jvm.Throws
 

--- a/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
@@ -11,7 +11,7 @@ import java.io.IOException
  * 現在はSamsung製のコーデックで確認したが、他にもベンダー独自のコーデックを仕込んでる可能性があるため
  * 逐次リストに定義する
  */
-class AvoidCodec {
+class AvoidBlackListCodec {
 
     companion object {
 
@@ -25,7 +25,7 @@ class AvoidCodec {
         )
 
         @JvmStatic
-        fun createDecoderWhileAvoidingBlackListCodec(mimeType: String): MediaCodec? {
+        fun createDecoder(mimeType: String): MediaCodec? {
 
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
@@ -44,7 +44,7 @@ class AvoidCodec {
         }
 
         @JvmStatic
-        fun createEncoderWhileAvoidingBlackList(mimeType: String): MediaCodec? {
+        fun createEncoder(mimeType: String): MediaCodec? {
 
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType) and codecInfo.isEncoder

--- a/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
@@ -52,6 +52,24 @@ class AvoidBlackListCodec {
 
         }
 
+        @JvmStatic
+        fun hasBlackListEncoder(mimeType: String): Boolean {
+            return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
+                codecInfo.supportedTypes.contains(mimeType) and codecInfo.isEncoder
+            }.any { codecInfo ->
+                isMatchingBlackList(codecInfo.name)
+            }
+        }
+
+        @JvmStatic
+        fun hasBlackListDecoder(mimeType: String): Boolean {
+            return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
+                codecInfo.supportedTypes.contains(mimeType) and !codecInfo.isEncoder
+            }.any { codecInfo ->
+                isMatchingBlackList(codecInfo.name)
+            }
+        }
+
         private fun isMatchingBlackList(codecName: String): Boolean {
             blackListCodec.forEach { targetCodec ->
                 if (codecName.contains(targetCodec, ignoreCase = true)) {

--- a/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
@@ -4,6 +4,7 @@ import android.media.MediaCodec
 import android.media.MediaCodecList
 import jp.studist.teachme_biz.controller.util.LogUtil
 import java.io.IOException
+import kotlin.jvm.Throws
 
 /**
  * 一部のコーデックにおいてエンコードまたはデコード、その他の処理が
@@ -25,41 +26,31 @@ class AvoidBlackListCodec {
         )
 
         @JvmStatic
-        fun createDecoder(mimeType: String): MediaCodec? {
+        @Throws(IOException::class)
+        fun createDecoder(mimeType: String): MediaCodec {
 
-            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
+            return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
             }.first { codecInfo ->
                 !isMatchingBlackList(codecInfo.name)
             }.let { codecInfo ->
-                try {
-                    return MediaCodec.createByCodecName(codecInfo.name)
-                } catch (e: IOException) {
-                    LogUtil.stackTrace(e)
-                    e.printStackTrace()
-                }
+                MediaCodec.createByCodecName(codecInfo.name)
             }
 
-            return null
         }
 
         @JvmStatic
-        fun createEncoder(mimeType: String): MediaCodec? {
+        @Throws(IOException::class)
+        fun createEncoder(mimeType: String): MediaCodec {
 
-            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
+            return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType) and codecInfo.isEncoder
             }.first { codecInfo ->
                 !isMatchingBlackList(codecInfo.name)
             }.let { codecInfo ->
-                try {
-                    return MediaCodec.createByCodecName(codecInfo.name)
-                } catch (e: IOException) {
-                    LogUtil.stackTrace(e)
-                    e.printStackTrace()
-                }
+                MediaCodec.createByCodecName(codecInfo.name)
             }
 
-            return null
         }
 
         private fun isMatchingBlackList(codecName: String): Boolean {

--- a/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
@@ -27,7 +27,6 @@ class AvoidBlackListCodec {
         @JvmStatic
         @Throws(IOException::class)
         fun createDecoder(mimeType: String): MediaCodec {
-
             return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType) and !codecInfo.isEncoder
             }.first { codecInfo ->
@@ -35,13 +34,11 @@ class AvoidBlackListCodec {
             }.let { codecInfo ->
                 MediaCodec.createByCodecName(codecInfo.name)
             }
-
         }
 
         @JvmStatic
         @Throws(IOException::class)
         fun createEncoder(mimeType: String): MediaCodec {
-
             return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType) and codecInfo.isEncoder
             }.first { codecInfo ->
@@ -49,7 +46,6 @@ class AvoidBlackListCodec {
             }.let { codecInfo ->
                 MediaCodec.createByCodecName(codecInfo.name)
             }
-
         }
 
         @JvmStatic

--- a/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidBlackListCodec.kt
@@ -29,7 +29,7 @@ class AvoidBlackListCodec {
         fun createDecoder(mimeType: String): MediaCodec {
 
             return MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
-                codecInfo.supportedTypes.contains(mimeType)
+                codecInfo.supportedTypes.contains(mimeType) and !codecInfo.isEncoder
             }.first { codecInfo ->
                 !isMatchingBlackList(codecInfo.name)
             }.let { codecInfo ->

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -9,14 +9,21 @@ import java.io.IOException
  * 一部のコーデックにおいてエンコードまたはデコード、その他の処理が
  * 正常に動作しない事象を確認したため、そのコーデックをブラックリストとして定義。
  * 現在はSamsung製のコーデックで確認したが、他にもベンダー独自のコーデックを仕込んでる可能性があるため
- * enumで列挙する
+ * 逐次リストに定義する
  */
-@Suppress("SpellCheckingInspection", "unused")
-enum class AvoidCodec(var codecPartialName: String) {
-    // Samsung社製のコーデック
-    EXYNOS("Exynos");
+class AvoidCodec {
 
     companion object {
+
+        /**
+         * ブラックリストとして選択しないコーデック名の定義
+         * ユニークに判断可能であれば部分的な名前で定義可能
+         */
+        private val blackListCodec = listOf(
+                // Samsung社製のコーデック
+                "Exynos"
+        )
+
         @JvmStatic
         fun createDecoderWhileAvoidingBlackListCodec(mimeType: String): MediaCodec? {
 
@@ -56,8 +63,8 @@ enum class AvoidCodec(var codecPartialName: String) {
         }
 
         private fun isNotMatchingAvoidCodec(codecName: String): Boolean {
-            values().forEach { avoidCodec ->
-                if (codecName.contains(avoidCodec.codecPartialName, ignoreCase = true)) {
+            blackListCodec.forEach { targetCodec ->
+                if (codecName.contains(targetCodec, ignoreCase = true)) {
                     return false
                 }
             }

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -30,7 +30,7 @@ class AvoidCodec {
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
             }.first { codecInfo ->
-                isNotMatchingAvoidCodec(codecInfo.name)
+                !isMatchingBlackList(codecInfo.name)
             }.let { codecInfo ->
                 try {
                     return MediaCodec.createByCodecName(codecInfo.name)
@@ -49,7 +49,7 @@ class AvoidCodec {
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType) and codecInfo.isEncoder
             }.first { codecInfo ->
-                isNotMatchingAvoidCodec(codecInfo.name)
+                !isMatchingBlackList(codecInfo.name)
             }.let { codecInfo ->
                 try {
                     return MediaCodec.createByCodecName(codecInfo.name)
@@ -62,14 +62,14 @@ class AvoidCodec {
             return null
         }
 
-        private fun isNotMatchingAvoidCodec(codecName: String): Boolean {
+        private fun isMatchingBlackList(codecName: String): Boolean {
             blackListCodec.forEach { targetCodec ->
                 if (codecName.contains(targetCodec, ignoreCase = true)) {
-                    return false
+                    return true
                 }
             }
 
-            return true
+            return false
         }
     }
 

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -20,8 +20,8 @@ enum class AvoidCodec(var codecPartialName: String) {
 
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
-            }.first {
-                isNotContainsAvoidCodec(it.name)
+            }.first { codecInfo ->
+                isNotContainsAvoidCodec(codecInfo.name)
             }.let { codecInfo ->
                 try {
                     return MediaCodec.createByCodecName(codecInfo.name)

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -16,12 +16,12 @@ enum class AvoidCodec(var codecPartialName: String) {
     EXYNOS("Exynos");
 
     companion object {
-        fun avoidBlackListCodec(mimeType: String): MediaCodec? {
+        fun createCodecWhileAvoidingBlackListCodec(mimeType: String): MediaCodec? {
 
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
             }.first { codecInfo ->
-                isNotContainsAvoidCodec(codecInfo.name)
+                isNotMatchingAvoidCodec(codecInfo.name)
             }.let { codecInfo ->
                 try {
                     return MediaCodec.createByCodecName(codecInfo.name)
@@ -34,7 +34,7 @@ enum class AvoidCodec(var codecPartialName: String) {
             return null
         }
 
-        private fun isNotContainsAvoidCodec(codecName: String): Boolean {
+        private fun isNotMatchingAvoidCodec(codecName: String): Boolean {
             values().forEach { avoidCodec ->
                 if (codecName.contains(avoidCodec.codecPartialName, ignoreCase = true)) {
                     return false

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -11,15 +11,36 @@ import java.io.IOException
  * 現在はSamsung製のコーデックで確認したが、他にもベンダー独自のコーデックを仕込んでる可能性があるため
  * enumで列挙する
  */
+@Suppress("SpellCheckingInspection", "unused")
 enum class AvoidCodec(var codecPartialName: String) {
     // Samsung社製のコーデック
     EXYNOS("Exynos");
 
     companion object {
-        fun createCodecWhileAvoidingBlackListCodec(mimeType: String): MediaCodec? {
+        @JvmStatic
+        fun createDecoderWhileAvoidingBlackListCodec(mimeType: String): MediaCodec? {
 
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
+            }.first { codecInfo ->
+                isNotMatchingAvoidCodec(codecInfo.name)
+            }.let { codecInfo ->
+                try {
+                    return MediaCodec.createByCodecName(codecInfo.name)
+                } catch (e: IOException) {
+                    LogUtil.stackTrace(e)
+                    e.printStackTrace()
+                }
+            }
+
+            return null
+        }
+
+        @JvmStatic
+        fun createEncoderWhileAvoidingBlackList(mimeType: String): MediaCodec? {
+
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
+                codecInfo.supportedTypes.contains(mimeType) and codecInfo.isEncoder
             }.first { codecInfo ->
                 isNotMatchingAvoidCodec(codecInfo.name)
             }.let { codecInfo ->

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -21,7 +21,7 @@ enum class AvoidCodec(var codecPartialName: String) {
             MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.filter { codecInfo ->
                 codecInfo.supportedTypes.contains(mimeType)
             }.first {
-                !containsShouldAvoidCodec(it.name)
+                isNotContainsAvoidCodec(it.name)
             }.let { codecInfo ->
                 try {
                     return MediaCodec.createByCodecName(codecInfo.name)
@@ -34,14 +34,14 @@ enum class AvoidCodec(var codecPartialName: String) {
             return null
         }
 
-        private fun containsShouldAvoidCodec(codecName: String): Boolean {
+        private fun isNotContainsAvoidCodec(codecName: String): Boolean {
             values().forEach { avoidCodec ->
                 if (codecName.contains(avoidCodec.codecPartialName, ignoreCase = true)) {
-                    return true
+                    return false
                 }
             }
 
-            return false
+            return true
         }
     }
 

--- a/android/src/main/java/org/m4m/android/AvoidCodec.kt
+++ b/android/src/main/java/org/m4m/android/AvoidCodec.kt
@@ -1,0 +1,70 @@
+package org.m4m.android
+
+import android.media.MediaCodec
+import android.media.MediaCodecList
+import jp.studist.teachme_biz.controller.util.LogUtil
+import java.io.IOException
+
+/**
+ * 一部のコーデックにおいてエンコードまたはデコード、その他の処理が
+ * 正常に動作しない事象を確認したため、そのコーデックをブラックリストとして定義。
+ * 現在はSamsung製のコーデックで確認したが、他にもベンダー独自のコーデックを仕込んでる可能性があるため
+ * enumで列挙する
+ */
+enum class AvoidCodec(var codecName: String) {
+    // Samsung社製のコーデック
+    EXYNOS("Exynos");
+
+    companion object {
+        fun shouldUseDecoder(mimeType: String): MediaCodec? {
+
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.forEach { codecInfo ->
+                codecInfo.supportedTypes.filter {
+                    containsShouldAvoidCodec(it)
+                }.first {
+                    !it.equals(mimeType, ignoreCase = true)
+                }.let {
+                    try {
+                        return MediaCodec.createDecoderByType(it)
+                    } catch (e: IOException) {
+                        LogUtil.stackTrace(e)
+                        e.printStackTrace()
+                    }
+                }
+            }
+
+            return null
+        }
+
+        fun shouldUseEncoder(mimeType: String): MediaCodec? {
+
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.forEach { codecInfo ->
+                codecInfo.supportedTypes.filter {
+                    containsShouldAvoidCodec(it)
+                }.first {
+                    !it.equals(mimeType, ignoreCase = true)
+                }.let {
+                    try {
+                        return MediaCodec.createEncoderByType(it)
+                    } catch (e: IOException) {
+                        LogUtil.stackTrace(e)
+                        e.printStackTrace()
+                    }
+                }
+            }
+
+            return null
+        }
+
+        private fun containsShouldAvoidCodec(codecType: String): Boolean {
+            values().forEach { avoidCodec ->
+                if (codecType.contains(avoidCodec.codecName, ignoreCase = true)) {
+                    return true
+                }
+            }
+
+            return false
+        }
+    }
+
+}

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -38,7 +38,7 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     public MediaCodecDecoderPlugin(String mime) {
 
 //        try {
-        this.mediaCodec = AvoidCodec.Companion.shouldUseDecoder(mime);
+        this.mediaCodec = AvoidCodec.Companion.avoidBlackListCodec(mime);
 //            this.mediaCodec = MediaCodec.createDecoderByType(mime);
         init();
 //        } catch (IOException e) {

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -39,24 +39,24 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     private MediaCodec.BufferInfo inputBufferInfo;
 
     public MediaCodecDecoderPlugin(String mime) {
+        try {
+            newMediaCodecInstance(mime);
+            init();
+        } catch (IOException e) {
+            LogUtil.stackTrace(e);
+        }
+    }
+
+    private void newMediaCodecInstance(String mime) throws IOException {
         if (this instanceof MediaCodecVideoDecoderPlugin) {
-            try {
-                if (AvoidBlackListCodec.hasBlackListDecoder(mime)) {
-                    this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
-                } else {
-                    this.mediaCodec = MediaCodec.createDecoderByType(mime);
-                }
-            } catch (IOException e) {
-                LogUtil.stackTrace(e);
+            if (AvoidBlackListCodec.hasBlackListDecoder(mime)) {
+                this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+            } else {
+                this.mediaCodec = MediaCodec.createDecoderByType(mime);
             }
         } else {
-            try {
-                this.mediaCodec = MediaCodec.createDecoderByType(mime);
-            } catch (IOException e) {
-                LogUtil.stackTrace(e);
-            }
+            this.mediaCodec = MediaCodec.createDecoderByType(mime);
         }
-        init();
     }
 
     private void init() {

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -24,7 +24,10 @@ import org.m4m.domain.ISurface;
 import org.m4m.domain.ISurfaceWrapper;
 import org.m4m.domain.MediaFormat;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+
+import jp.studist.teachme_biz.controller.util.LogUtil;
 
 public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     protected MediaCodec mediaCodec;
@@ -36,7 +39,16 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     private MediaCodec.BufferInfo inputBufferInfo;
 
     public MediaCodecDecoderPlugin(String mime) {
-        this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+        if (this instanceof MediaCodecVideoDecoderPlugin) {
+            this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+        } else {
+            try {
+                this.mediaCodec = MediaCodec.createDecoderByType(mime);
+            } catch (IOException e) {
+                LogUtil.stackTrace(e);
+                e.printStackTrace();
+            }
+        }
         init();
     }
 

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -48,14 +48,12 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
                 }
             } catch (IOException e) {
                 LogUtil.stackTrace(e);
-                e.printStackTrace();
             }
         } else {
             try {
                 this.mediaCodec = MediaCodec.createDecoderByType(mime);
             } catch (IOException e) {
                 LogUtil.stackTrace(e);
-                e.printStackTrace();
             }
         }
         init();

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -36,7 +36,7 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     private MediaCodec.BufferInfo inputBufferInfo;
 
     public MediaCodecDecoderPlugin(String mime) {
-        this.mediaCodec = AvoidCodec.createDecoderWhileAvoidingBlackListCodec(mime);
+        this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
         init();
     }
 

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -24,7 +24,6 @@ import org.m4m.domain.ISurface;
 import org.m4m.domain.ISurfaceWrapper;
 import org.m4m.domain.MediaFormat;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
@@ -38,12 +37,14 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
 
     public MediaCodecDecoderPlugin(String mime) {
 
-        try {
-            this.mediaCodec = MediaCodec.createDecoderByType(mime);
-            init();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+//        try {
+        this.mediaCodec = AvoidCodec.Companion.shouldUseDecoder(mime);
+//            this.mediaCodec = MediaCodec.createDecoderByType(mime);
+        init();
+//        } catch (IOException e) {
+//            LogUtil.stackTrace(e);
+//            e.printStackTrace();
+//        }
     }
 
     private void init() {

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -40,7 +40,12 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
 
     public MediaCodecDecoderPlugin(String mime) {
         if (this instanceof MediaCodecVideoDecoderPlugin) {
-            this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+            try {
+                this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+            } catch (IOException e) {
+                LogUtil.stackTrace(e);
+                e.printStackTrace();
+            }
         } else {
             try {
                 this.mediaCodec = MediaCodec.createDecoderByType(mime);

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -41,7 +41,11 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     public MediaCodecDecoderPlugin(String mime) {
         if (this instanceof MediaCodecVideoDecoderPlugin) {
             try {
-                this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+                if (AvoidBlackListCodec.hasBlackListDecoder(mime)) {
+                    this.mediaCodec = AvoidBlackListCodec.createDecoder(mime);
+                } else {
+                    this.mediaCodec = MediaCodec.createDecoderByType(mime);
+                }
             } catch (IOException e) {
                 LogUtil.stackTrace(e);
                 e.printStackTrace();

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -38,7 +38,7 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     public MediaCodecDecoderPlugin(String mime) {
 
 //        try {
-        this.mediaCodec = AvoidCodec.Companion.avoidBlackListCodec(mime);
+        this.mediaCodec = AvoidCodec.Companion.createCodecWhileAvoidingBlackListCodec(mime);
 //            this.mediaCodec = MediaCodec.createDecoderByType(mime);
         init();
 //        } catch (IOException e) {

--- a/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecDecoderPlugin.java
@@ -36,15 +36,8 @@ public abstract class MediaCodecDecoderPlugin implements IMediaCodec {
     private MediaCodec.BufferInfo inputBufferInfo;
 
     public MediaCodecDecoderPlugin(String mime) {
-
-//        try {
-        this.mediaCodec = AvoidCodec.Companion.createCodecWhileAvoidingBlackListCodec(mime);
-//            this.mediaCodec = MediaCodec.createDecoderByType(mime);
+        this.mediaCodec = AvoidCodec.createDecoderWhileAvoidingBlackListCodec(mime);
         init();
-//        } catch (IOException e) {
-//            LogUtil.stackTrace(e);
-//            e.printStackTrace();
-//        }
     }
 
     private void init() {

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -52,7 +52,7 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
 //        try {
         this.eglUtil = eglUtil;
         init();
-        this.mediaCodec = AvoidCodec.Companion.shouldUseEncoder(mime);
+        this.mediaCodec = AvoidCodec.Companion.avoidBlackListCodec(mime);
 
 //        } catch (IOException e) {
 //            e.printStackTrace();

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -59,7 +59,6 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
             }
         } catch (IOException e) {
             LogUtil.stackTrace(e);
-            e.printStackTrace();
         }
     }
 

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -49,7 +49,7 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
     public MediaCodecEncoderPlugin(String mime, IEglUtil eglUtil) {
         this.eglUtil = eglUtil;
         init();
-        this.mediaCodec = AvoidCodec.createEncoderWhileAvoidingBlackList(mime);
+        this.mediaCodec = AvoidBlackListCodec.createEncoder(mime);
     }
 
     private void init() {

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -52,7 +52,7 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
 //        try {
         this.eglUtil = eglUtil;
         init();
-        this.mediaCodec = AvoidCodec.Companion.avoidBlackListCodec(mime);
+        this.mediaCodec = AvoidCodec.Companion.createCodecWhileAvoidingBlackListCodec(mime);
 
 //        } catch (IOException e) {
 //            e.printStackTrace();

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -52,7 +52,11 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
         this.eglUtil = eglUtil;
         init();
         try {
-            this.mediaCodec = AvoidBlackListCodec.createEncoder(mime);
+            if (AvoidBlackListCodec.hasBlackListEncoder(mime)) {
+                this.mediaCodec = AvoidBlackListCodec.createEncoder(mime);
+            } else {
+                this.mediaCodec = MediaCodec.createEncoderByType(mime);
+            }
         } catch (IOException e) {
             LogUtil.stackTrace(e);
             e.printStackTrace();

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -21,14 +21,13 @@ import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.opengl.EGLContext;
 
-import org.m4m.domain.graphics.IEglUtil;
-
 import org.m4m.domain.IEglContext;
 import org.m4m.domain.IMediaCodec;
 import org.m4m.domain.ISurface;
 import org.m4m.domain.ISurfaceWrapper;
 import org.m4m.domain.IWrapper;
 import org.m4m.domain.MediaFormat;
+import org.m4m.domain.graphics.IEglUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -48,15 +47,9 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
         init();
     }
     public MediaCodecEncoderPlugin(String mime, IEglUtil eglUtil) {
-
-//        try {
         this.eglUtil = eglUtil;
         init();
-        this.mediaCodec = AvoidCodec.Companion.createCodecWhileAvoidingBlackListCodec(mime);
-
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
+        this.mediaCodec = AvoidCodec.createEncoderWhileAvoidingBlackList(mime);
     }
 
     private void init() {

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -32,6 +32,8 @@ import org.m4m.domain.graphics.IEglUtil;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import jp.studist.teachme_biz.controller.util.LogUtil;
+
 public class MediaCodecEncoderPlugin implements IMediaCodec {
     private MediaCodec mediaCodec;
 
@@ -49,7 +51,12 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
     public MediaCodecEncoderPlugin(String mime, IEglUtil eglUtil) {
         this.eglUtil = eglUtil;
         init();
-        this.mediaCodec = AvoidBlackListCodec.createEncoder(mime);
+        try {
+            this.mediaCodec = AvoidBlackListCodec.createEncoder(mime);
+        } catch (IOException e) {
+            LogUtil.stackTrace(e);
+            e.printStackTrace();
+        }
     }
 
     private void init() {

--- a/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
+++ b/android/src/main/java/org/m4m/android/MediaCodecEncoderPlugin.java
@@ -49,14 +49,14 @@ public class MediaCodecEncoderPlugin implements IMediaCodec {
     }
     public MediaCodecEncoderPlugin(String mime, IEglUtil eglUtil) {
 
-        try {
-            this.eglUtil = eglUtil;
-            init();
-            this.mediaCodec = MediaCodec.createEncoderByType(mime);
+//        try {
+        this.eglUtil = eglUtil;
+        init();
+        this.mediaCodec = AvoidCodec.Companion.shouldUseEncoder(mime);
 
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
     }
 
     private void init() {


### PR DESCRIPTION
## 背景
動画の編集において一部ベンダー端末で動作しない不具合を確認された。
その上で、同じベンダー端末でも、再現する端末／しない端末があることも確認された。

その差分として、アジアやヨーロッパ、北アメリカなどの販売される地域により
同じベンダーでも搭載されるプラットフォーム（チップセット）が異なることを確認した。



## 原因
端末のチップセットごとに利用される各ベンダー固有のコーデックが存在し、
その中でも、正常に動作する／しないコーデックがあったこと。

## 対策（修正内容）
一部ベンダーのコーデックが利用されるのを回避する実装を追加。