### PR TITLE
一定時間エンコード・デコードができなかったら例外を発生させる

### DIFF
--- a/domain/src/main/java/org/m4m/domain/ICommandProcessor.java
+++ b/domain/src/main/java/org/m4m/domain/ICommandProcessor.java
@@ -16,8 +16,10 @@
 
 package org.m4m.domain;
 
+import java.util.concurrent.TimeoutException;
+
 public interface ICommandProcessor {
-    void process();
+    void process() throws TimeoutException;
 
     void add(OutputInputPair pair);
 


### PR DESCRIPTION
## 背景
Android 10以上の一部端末でエンコード・デコードが進まなくなる問題が発生する。

## 原因
各プロセスで規定の条件に一致せず無限ループが発生している。

## 対策（修正内容）
一定時間経過後（10秒）にTimeoutExceptionを投げる。

## System. currentTimeMillis()が遅い問題

### ~~エンコード時間の計測~~
実際に処理がどの程度遅くなるのか計測を行った。（Pixel4a, 23s動画にマーキング3つ追加）

#### タイムアウト実装前
(25113 + 24935 + 25013) / 3 = 25020ms

#### タイムアウト実装後
(28644 + 28396 + 28603) / 3 = 28548ms

少し時間をおいて計測するとタイムアウト実装前で27708msになることもあり不安定なため別の計測方法を検討。

### 理論値から遅延時間を求める
コメントにある[リンク](https://postd.cc/the-slow-currenttimemillis/)より`System. currentTimeMillis()`の実行にかかる時間は0.5マイクロ秒とする。
※`System. currentTimeMillis()`の実行にかかる時間は端末の性能により差がある

**System. currentTimeMillis()の呼び出し回数**
1分19秒の動画の場合は28215回　→　28215 * 0.55 = 15518μs ≒ 15.5ms
9分59秒の動画の場合は223956回　→　223956 * 0.55 = 123176μs ≒ 124ms