### PR TITLE
Android 12でMediaFormatが取得できない問題修正

### DIFF
--- a/domain/src/main/java/org/m4m/domain/MediaSource.java
+++ b/domain/src/main/java/org/m4m/domain/MediaSource.java
@@ -155,7 +155,10 @@ public class MediaSource implements IMediaSource {
     public Iterable<MediaFormat> getMediaFormats() {
         LinkedList<MediaFormat> result = new LinkedList<MediaFormat>();
         for (int i = 0; i < mediaExtractor.getTrackCount(); i++) {
-            result.add(mediaExtractor.getTrackFormat(i));
+            MediaFormat mediaFormat = mediaExtractor.getTrackFormat(i);
+            if (mediaFormat != null) {
+                result.add(mediaFormat);
+            }
         }
         return result;
     }


### PR DESCRIPTION
## 背景
Android 12において動画のトランスコードができない問題があった。

## 原因と対策
Android 12において`getMediaFormats()`実行時に返すとIteratorにnullが含まれていることが原因だったため、nullの場合は要素を追加しないように修正した。