### PR TITLE
jcenter終了に伴うレポジトリ移行

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         mavenCentral()
     }
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 25
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implemantation project(':domain')
+    implementation project(':domain')
     testImplementation 'junit:junit:4.12'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,8 +32,8 @@ android {
 }
 
 dependencies {
-    compile project(':domain')
-    testCompile 'junit:junit:4.12'
+    implemantation project(':domain')
+    testImplementation 'junit:junit:4.12'
 }
 
 version = android.defaultConfig.versionName

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.android.tools.build:gradle:3.2.0-alpha12'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0-RC2"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         mavenCentral()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext.kotlin_version = '1.6.0-RC2'
     repositories {
         google()
         mavenCentral()
@@ -7,7 +8,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 dependencies {
     testCompile 'junit:junit:4.12'

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -7,7 +7,11 @@ repositories {
 }
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    configurations.all {
+        resolutionStrategy {
+            force "org.hamcrest:hamcrest-core:2.2"
+        }
+    }
     testImplementation 'org.mockito:mockito-all:1.9.5'
 }
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
+repositories {
+    mavenCentral()
+}
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'maven'
 
 repositories {
     mavenCentral()

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -6,9 +6,9 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile 'org.mockito:mockito-all:1.9.5'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'org.mockito:mockito-all:1.9.5'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/effects/build.gradle
+++ b/effects/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         mavenCentral()
     }
     dependencies {

--- a/effects/build.gradle
+++ b/effects/build.gradle
@@ -13,7 +13,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 18

--- a/effects/build.gradle
+++ b/effects/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion 25

--- a/effects/build.gradle
+++ b/effects/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/effects/build.gradle
+++ b/effects/build.gradle
@@ -30,8 +30,8 @@ android {
 }
 
 dependencies {
-    compile project(':domain')
-    compile project(':android')
+    implementation project(':domain')
+    implementation project(':android')
 }
 
 group = "org.m4m"

--- a/effects/build.gradle
+++ b/effects/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0-RC2"
     }
 }
 

--- a/effects/src/main/AndroidManifest.xml
+++ b/effects/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
           android:versionCode="1"
           android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="18"/>
-
     <uses-feature
             android:glEsVersion="0x00020000"
             android:required="true"/>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 15 11:33:07 CEST 2017
+#Thu Nov 11 16:26:49 JST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -21,6 +21,7 @@ android {
 
 allprojects {
     repositories {
+        google()
         mavenCentral()
     }
     dependencies {

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -25,8 +25,8 @@ allprojects {
         mavenCentral()
     }
     dependencies {
-        compile project(':domain')
-        compile project(':android')
-        compile project(':effects')
+        implementation project(':domain')
+        implementation project(':android')
+        implementation project(':effects')
     }
 }

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -19,8 +19,13 @@ android {
     }
 }
 
-dependencies {
-    compile project(':domain')
-    compile project(':android')
-    compile project(':effects')
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        compile project(':domain')
+        compile project(':android')
+        compile project(':effects')
+    }
 }

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "org.m4m.samples"


### PR DESCRIPTION
## 概要
参照先レポジトリからjcenterを削除して、mavenCentral、googleなどを追加する。

## 変更・追加点
repositoriesに参照先を追加、dependenciesにclasspathを追加、compile → implementation に変更

## 検証
- [x] graldeの同期がエラーなく終了する
- [x] ビルド前クリーンがエラーなく終了する
- [x] ビルドがエラーなく終了する
- [x] 本体アプリと繋ぎ込んでビルド後、動画再生の動作確認を実施

## レビュー観点
- [] Design
- [] Naming
- [] Functionality
- [] Comments
- [] Complexity
- [] Tests
- [x] other

## レビューで特に見てほしい箇所
build.gradle の警告、gradle同期時、ビルド時のメッセージ
